### PR TITLE
Make arch flags optional to enable compilation (e.g. linux-aarch64)

### DIFF
--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -1,4 +1,5 @@
-COMMON_CFLAGS := -m64 -fPIC -march=skylake -Wall -Wextra -Wvla -Wswitch-enum -Wno-missing-field-initializers -fdiagnostics-color=always
+ARCH_CFLAGS ?= -m64 -march=skylake
+COMMON_CFLAGS := $(ARCH_CFLAGS) -fPIC -Wall -Wextra -Wvla -Wswitch-enum -Wno-missing-field-initializers -fdiagnostics-color=always
 DEBUG ?= 1
 
 ifeq ($(DEBUG), 1)


### PR DESCRIPTION
Making arch flags optional to enable compilation for aarch64 Linux versions