### PR TITLE
'cmp_key_metadata' struct definition fix

### DIFF
--- a/include/cosigner/cmp_ecdsa_signing_service.h
+++ b/include/cosigner/cmp_ecdsa_signing_service.h
@@ -22,7 +22,7 @@ namespace mta
 
 class cmp_key_persistency;
 class platform_service;
-class cmp_key_metadata;
+struct cmp_key_metadata;
 struct auxiliary_keys;
 
 struct cmp_mta_message


### PR DESCRIPTION
'cmp_key_metadata' is defined as struct and current code gives an error on macOS (tested on Ventura 13.6)

```
In file included from cosigner/mta.cpp:2:
../../include/cosigner/cmp_key_persistency.h:28:1: error: 'cmp_key_metadata' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
struct cmp_key_metadata
^
../../include/cosigner/cmp_ecdsa_signing_service.h:25:1: note: did you mean struct here?
class cmp_key_metadata;
^~~~~
struct
```

`clang` version:
```
% clang -v
Apple clang version 15.0.0 (clang-1500.0.40.1)
Target: arm64-apple-darwin22.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

```

Also tested with `gcc version 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04)` on Linux:
`Linux asgard 5.15.0-86-generic #96-Ubuntu SMP Wed Sep 20 08:29:36 UTC 2023 aarch64 aarch64 aarch64 GNU/Linux`
 
