### PR TITLE
byteswap.h is not present on macOS

### DIFF
--- a/include/port.h
+++ b/include/port.h
@@ -1,0 +1,26 @@
+#ifndef __MPC_LIB_PORT_H__
+#define __MPC_LIB_PORT_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif //__cplusplus
+
+#if HAVE_BYTESWAP_H
+#include <byteswap.h>
+#else
+    // bswap_xx macros
+    #if defined(__APPLE__)
+        #include <libkern/OSByteOrder.h>
+        #define bswap_16(x) OSSwapInt16(x)
+        #define bswap_32(x) OSSwapInt32(x)
+        #define bswap_64(x) OSSwapInt64(x)
+    #else
+        #error bswap_xx macros should be defined
+    #endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif //__cplusplus
+
+#endif // __MPC_LIB_PORT_H__

--- a/src/common/crypto/GFp_curve_algebra/GFp_curve_algebra.c
+++ b/src/common/crypto/GFp_curve_algebra/GFp_curve_algebra.c
@@ -2,7 +2,7 @@
 
 #include <string.h>
 #include <assert.h>
-#include <byteswap.h>
+#include "port.h"
 
 #include <openssl/bn.h>
 #include <openssl/err.h>

--- a/src/common/crypto/ed25519_algebra/ed25519_algebra.c
+++ b/src/common/crypto/ed25519_algebra/ed25519_algebra.c
@@ -3,7 +3,7 @@
 #include "crypto/keccak1600/keccak1600.h"
 #include "curve25519.c"
 
-#include <byteswap.h>
+#include "port.h"
 
 #include <openssl/bn.h>
 #include <openssl/sha.h>

--- a/src/common/crypto/zero_knowledge_proof/diffie_hellman_log.c
+++ b/src/common/crypto/zero_knowledge_proof/diffie_hellman_log.c
@@ -1,6 +1,6 @@
 #include "crypto/zero_knowledge_proof/diffie_hellman_log.h"
 #include "crypto/drng/drng.h"
-#include <byteswap.h>
+#include "port.h"
 #include <string.h>
 #include <openssl/sha.h>
 

--- a/test/crypto/ed25519_algebra/tests.cpp
+++ b/test/crypto/ed25519_algebra/tests.cpp
@@ -4,7 +4,7 @@
 #include <openssl/rand.h>
 #include <openssl/bn.h>
 
-#include <byteswap.h>
+#include "port.h"
 #include <string.h>
 
 #include <tests/catch.hpp>

--- a/test/crypto/secp256k1_algebra/tests.cpp
+++ b/test/crypto/secp256k1_algebra/tests.cpp
@@ -5,7 +5,7 @@
 #include <openssl/objects.h>
 #include <openssl/rand.h>
 
-#include <byteswap.h>
+#include "port.h"
 #include <string.h>
 
 #include <tests/catch.hpp>


### PR DESCRIPTION
Projects like Chromium use a porting header to handle platform differences like these and a port.h is added to local include folder