### PR TITLE
fixes non-cmake build issues for macOS

### DIFF
--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -23,7 +23,7 @@ Cpp_Files := cosigner/cosigner_exception.cpp cosigner/cmp_setup_service.cpp cosi
 
 Cpp_Objects := $(Cpp_Files:.cpp=.o)
 
-Include_Paths := -I. -I../../include
+Include_Paths := -I. -I../../include -I$(DEPS_INCLUDEDIR)
 
 C_Flags := $(COMMON_CFLAGS) -fstack-protector-strong
 C_Flags += $(Include_Paths)
@@ -31,7 +31,7 @@ C_Flags += -Wno-unknown-pragmas
 
 Cpp_Flags := $(C_Flags) -std=c++17 -Wno-overloaded-virtual
 
-Link_Flags := $(COMMON_CFLAGS) -shared -Wl,--version-script=lib.lds -Wl,--no-undefined -Wl,-Bstatic -lcrypto -Wl,-Bdynamic -lpthread -ldl
+Link_Flags := $(COMMON_CFLAGS) -shared -L$(DEPS_LIBDIR) -lcrypto -lpthread -ldl
 
 Lib_Name := libcosigner.so
 

--- a/test/cosigner/Makefile
+++ b/test/cosigner/Makefile
@@ -1,8 +1,8 @@
 App_Name := test
 
-App_C_Flags := -g -I../../include -DTEST_ONLY
+App_C_Flags := -g -I../../include -I$(DEPS_INCLUDEDIR) -DTEST_ONLY
 App_Cpp_Flags := $(App_C_Flags) -std=c++17
-App_Link_Flags := -L../../src/common -lcosigner -Wl,-Bstatic -lcrypto -Wl,-Bdynamic -luuid -lsecp256k1 -pthread -ldl
+App_Link_Flags := -L../../src/common -lcosigner -L$(DEPS_LIBDIR) -lcrypto -luuid -lsecp256k1 -pthread -ldl
 
 App_Cpp_Files := $(wildcard ./*.cpp) ../tests_main.cpp
 App_Cpp_Objects := $(App_Cpp_Files:.cpp=.o)

--- a/test/crypto/drng/Makefile
+++ b/test/crypto/drng/Makefile
@@ -1,8 +1,8 @@
 App_Name := test
 
-App_C_Flags := -g -Wall -Wextra -I../../../include
+App_C_Flags := -g -Wall -Wextra -I../../../include -I$(DEPS_INCLUDEDIR)
 App_Cpp_Flags := $(App_C_Flags) -std=c++17
-App_Link_Flags := -lcrypto
+App_Link_Flags := -L$(DEPS_LIBDIR) -lcrypto
 
 all: $(App_Name)
 

--- a/test/crypto/ed25519_algebra/Makefile
+++ b/test/crypto/ed25519_algebra/Makefile
@@ -1,8 +1,8 @@
 App_Name := test
 
-App_C_Flags := -g -Wall -Wextra -I../../../include
+App_C_Flags := -g -Wall -Wextra -I../../../include -I$(DEPS_INCLUDEDIR)
 App_Cpp_Flags := $(App_C_Flags) -std=c++17
-App_Link_Flags := -Wl,-Bstatic -lcrypto -Wl,-Bdynamic -pthread -ldl
+App_Link_Flags := -L$(DEPS_LIBDIR) -lcrypto -pthread -ldl
 
 all: $(App_Name)
 

--- a/test/crypto/paillier/Makefile
+++ b/test/crypto/paillier/Makefile
@@ -1,8 +1,8 @@
 App_Name := test
 
-App_C_Flags := -g -Wall -Wextra -I../../../include
+App_C_Flags := -g -Wall -Wextra -I../../../include -I$(DEPS_INCLUDEDIR)
 App_Cpp_Flags := $(App_C_Flags) -std=c++17
-App_Link_Flags := -lcrypto
+App_Link_Flags := -L$(DEPS_LIBDIR) -lcrypto
 
 all: $(App_Name)
 

--- a/test/crypto/secp256k1_algebra/Makefile
+++ b/test/crypto/secp256k1_algebra/Makefile
@@ -1,8 +1,8 @@
 App_Name := test
 
-App_C_Flags := -g -Wall -Wextra -I../../../include
+App_C_Flags := -g -Wall -Wextra -I../../../include -I$(DEPS_INCLUDEDIR)
 App_Cpp_Flags := $(App_C_Flags) -std=c++17
-App_Link_Flags := -lcrypto
+App_Link_Flags := -L$(DEPS_LIBDIR) -lcrypto
 
 all: $(App_Name)
 

--- a/test/crypto/shamir_secret_sharing/Makefile
+++ b/test/crypto/shamir_secret_sharing/Makefile
@@ -1,8 +1,8 @@
 App_Name := test
 
-App_C_Flags := -g -Wall -Wextra -I../../../include
+App_C_Flags := -g -Wall -Wextra -I../../../include -I$(DEPS_INCLUDEDIR)
 App_Cpp_Flags := $(App_C_Flags) -std=c++17
-App_Link_Flags := -Wl,-Bstatic -lcrypto -Wl,-Bdynamic -pthread -ldl
+App_Link_Flags := -L$(DEPS_LIBDIR) -lcrypto -pthread -ldl
 
 all: $(App_Name)
 

--- a/test/crypto/zero_knowledge_proof/Makefile
+++ b/test/crypto/zero_knowledge_proof/Makefile
@@ -1,8 +1,8 @@
 App_Name := test
 
-App_C_Flags := -g -O0 -Wall -Wextra -I../../../include
+App_C_Flags := -g -O0 -Wall -Wextra -I../../../include -I$(DEPS_INCLUDEDIR)
 App_Cpp_Flags := $(App_C_Flags) -std=c++17
-App_Link_Flags := -Wl,-Bstatic -lcrypto -Wl,-Bdynamic -ldl -pthread
+App_Link_Flags := -L$(DEPS_LIBDIR) -lcrypto -ldl -pthread
 
 all: $(App_Name)
 


### PR DESCRIPTION
fixes two issues for non-cmake builds on macOS:
- adds `DEPS_INCLUDEDIR` and `DEPS_LIBDIR` params for specifying custom dependency paths
- removes unsupported `--version-script=lib.lds`, `--no-undefined`, `-Bstatic` and `-Bdynamic` linker flags