### PR TITLE
Docs: harmless Dockerfile comment for automation probe

### DIFF
--- a/docker/Dockerfile.focal
+++ b/docker/Dockerfile.focal
@@ -1,4 +1,5 @@
 FROM ubuntu:focal
+# Probe: harmless comment for Snyk/PR automation observation.
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
This PR adds one harmless comment to docker/Dockerfile.focal for minimal automation observation.