### PR TITLE
fix: ~ecdsa_preprocessing_data cleanses over live std::map/std::vector members (UB + leak)

### DIFF
--- a/include/cosigner/cmp_ecdsa_signing_service.h
+++ b/include/cosigner/cmp_ecdsa_signing_service.h
@@ -82,7 +82,21 @@ struct ecdsa_preprocessing_data
     byte_vector_t mta_request;
     std::map<uint64_t, byte_vector_t> G_proofs;
     std::map<uint64_t, ecdsa_signing_public_data> public_data;
-    ~ecdsa_preprocessing_data() {OPENSSL_cleanse(k.data, sizeof(ecdsa_preprocessing_data));}
+    ~ecdsa_preprocessing_data()
+    {
+        // Wipe each secret scalar individually. Passing sizeof(ecdsa_preprocessing_data)
+        // to OPENSSL_cleanse() spans the non-trivial members below (mta_request, G_proofs,
+        // public_data); since this destructor body runs before the implicit member
+        // destructors, it would zero the live std::vector/std::map control blocks and the
+        // subsequent ~vector/~map would then run on zeroed internals (UB + leak).
+        // Mirrors the correct pattern in eddsa_signature_data (eddsa_online_signing_service.h).
+        OPENSSL_cleanse(k.data, sizeof(k.data));
+        OPENSSL_cleanse(gamma.data, sizeof(gamma.data));
+        OPENSSL_cleanse(a.data, sizeof(a.data));
+        OPENSSL_cleanse(b.data, sizeof(b.data));
+        OPENSSL_cleanse(delta.data, sizeof(delta.data));
+        OPENSSL_cleanse(chi.data, sizeof(chi.data));
+    }
 };
 
 // this class holds the common functionality for cmp_ecdsa_online_signing_service and cmp_ecdsa_offline_signing_service


### PR DESCRIPTION
### Problem

`ecdsa_preprocessing_data` (in `include/cosigner/cmp_ecdsa_signing_service.h`) has:

```cpp
~ecdsa_preprocessing_data() { OPENSSL_cleanse(k.data, sizeof(ecdsa_preprocessing_data)); }
```

`k` is the first member, so `k.data` aliases the object base — but the **size** passed is
`sizeof(ecdsa_preprocessing_data)`, i.e. the entire struct. That span covers the three
non-trivially-destructible members:

```cpp
byte_vector_t                                  mta_request;   // std::vector
std::map<uint64_t, byte_vector_t>              G_proofs;      // std::map
std::map<uint64_t, ecdsa_signing_public_data>  public_data;   // std::map
```

A user-declared destructor **body runs before** the implicit member destructors, so the
`OPENSSL_cleanse` zeroes the **live** control blocks of the vector and the two maps
(begin/end/root pointers, node counts). The subsequent `~vector` / `~map` then run on those
zeroed internals — **undefined behaviour**, and in practice a **heap leak** of every map node
and vector buffer (these are populated per-signing from peer messages).

### Fix

Cleanse each secret scalar individually and let the containers destruct normally. This mirrors
the correct pattern already used by the EdDSA analog `eddsa_signature_data`
(`include/cosigner/eddsa_online_signing_service.h`), which cleanses `sizeof(k.data)` rather than
the whole struct.

### Notes

- Behaviour-preserving for the intended goal (all secret scalars `k, gamma, a, b, delta, chi`
  are still wiped); only the erroneous over-write of the live container internals is removed.
- This is a correctness / memory-hygiene fix — not a remotely exploitable issue (the write stays
  within the object; no OOB).
- Suggested validation: build with `-fsanitize=address` and run `ecdsa_online_test` /
  `ecdsa_offline_test`; LeakSanitizer flags the orphaned allocations before this change and is
  clean after.